### PR TITLE
Switch protocol-relative URLs to SSL for CloudFlare CDN assets

### DIFF
--- a/lib/flamegraph/renderer.rb
+++ b/lib/flamegraph/renderer.rb
@@ -12,9 +12,9 @@ class Flamegraph::Renderer
       if embed_resources
         embed("jquery.min.js","d3.min.js","lodash.min.js")
       else
-        '<script src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-<script src="//cdnjs.cloudflare.com/ajax/libs/d3/3.0.8/d3.min.js"></script>
-<script src="//cdnjs.cloudflare.com/ajax/libs/lodash.js/1.3.1/lodash.min.js"></script>'
+        '<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.0.8/d3.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/1.3.1/lodash.min.js"></script>'
       end
 
     body.sub!("/**DATA**/", ::JSON.generate(graph_data));


### PR DESCRIPTION
I use flamegraph in conjunction with rack-mini-profiler extensively to test our app locally, with flamegraph output saved to disk (via cURL, via Save As ..., etc).

This worked amazingly well with rack-mini-profiler 0.1.26, but breaks on HEAD of the extracted flamegraph gem.  CloudFlare CDN assets look like: 

```
file://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js
```

This fails.

Not sure how you feel about this, but always using https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js would work in all protocols (http, https, file) :+1: 
