### PR TITLE
Fix fontSize performance

### DIFF
--- a/lib/flamegraph/flamegraph.html
+++ b/lib/flamegraph/flamegraph.html
@@ -291,7 +291,7 @@ function fontSize(d,i) {
   var height = yScale(1);
   var length = 0;
   d3.select(this).style("font-size", size + "px").text(word);
-  while(((this.getBBox().width >= width) || (this.getBBox().height >= height)) && (size > 12))
+  while((size > 12.1) && ((this.getBBox().width >= width) || (this.getBBox().height >= height)))
    {
     size -= 0.1;
     d3.select(this).style("font-size", size + "px");


### PR DESCRIPTION
Only call expensive getBBox method if needed.
This reduces execution time for the rails-startup example from
1m20s to 6.5s (measured in Safari 7.01).
