### PR TITLE
Support JRuby by removing fast_stack as a hard dependency

### DIFF
--- a/flamegraph.gemspec
+++ b/flamegraph.gemspec
@@ -18,11 +18,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "fast_stack"
-
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "guard"
   spec.add_development_dependency "guard-minitest"
+  spec.add_development_dependency "fast_stack"
 end

--- a/lib/flamegraph.rb
+++ b/lib/flamegraph.rb
@@ -11,12 +11,15 @@ else
   begin
     require "fast_stack"
   rescue LoadError
-    STDERR.puts "Please require the fast_stack gem, note flamegraph is only supported on Ruby 2.0 and above"
+    unless RUBY_PLATFORM == 'java'
+      STDERR.puts "Please require the fast_stack gem, note flamegraph is only supported on Ruby 2.0 and above"
+    end
   end
 end
 
 require "flamegraph/version"
 require "flamegraph/renderer"
+require "flamegraph/sampler"
 
 module Flamegraph
   def self.generate(filename=nil, opts = {})
@@ -28,8 +31,12 @@ module Flamegraph
         StackProfSampler.collect(fidelity) do
           yield
         end
-      else
+      elsif defined? FastStack
         FastStack.profile(fidelity) do # , opts[:mode] || :ruby) do
+          yield
+        end
+      else
+        Sampler.collect(fidelity) do
           yield
         end
       end


### PR DESCRIPTION
Since fast_stack uses a C extension, it is not compatible with JRuby. With this patch, fast_stack will be used when it is available, only after after using StackProf if that is available.

Tested manually on JRuby, and the specs still pass on MRI.

What do you think about this approach?