### PR TITLE
Initial filtering prototype

### DIFF
--- a/lib/flamegraph/renderer.rb
+++ b/lib/flamegraph/renderer.rb
@@ -26,13 +26,11 @@ class Flamegraph::Renderer
     prev = []
 
     # a 2d array makes collapsing easy
-    @stacks.each_with_index do |stack, pos|
-
-      next unless stack
+    @stacks.map! { |s| s.map!(&:to_s).reverse! }.delete_if{|s| s.to_a.empty? }.sort_by!{|a| a }.each_with_index do |stack, pos|
 
       col = []
 
-      stack.reverse.map{|r| r.to_s}.each_with_index do |frame, i|
+      stack.each_with_index do |frame, i|
 
         if !prev[i].nil?
           last_col = prev[i]


### PR DESCRIPTION
I find that the lowest frames of the stack trace can often be in the way, and prevent otherwise adjacent frames from being combined. This is what I've been doing to throw out the rack and passenger frames, and is by no means merge-worthy but I find it's a good spot to throw out unwanted data and figured I'd share. Maybe you'll have an idea how to make this usable in a general sense.

The attached screenshots show the difference that even this crude version can make.

![screen shot 2015-05-25 at 3 23 21 pm](https://cloud.githubusercontent.com/assets/6243207/7802444/b0d24a74-02f2-11e5-9083-eddf29a50dec.png)
![screen shot 2015-05-25 at 3 21 19 pm](https://cloud.githubusercontent.com/assets/6243207/7802443/b0d10862-02f2-11e5-8d3c-28ccaa792d9b.png)
