### PR TITLE
Added a nil guard

### DIFF
--- a/lib/flamegraph/stackprof_sampler.rb
+++ b/lib/flamegraph/stackprof_sampler.rb
@@ -12,7 +12,7 @@ class Flamegraph::StackProfSampler
     stacks = []
     stack = []
 
-    return [] unless result[:raw]
+    return [] unless result && result[:raw]
 
     length = nil
     result[:raw].each do |i|


### PR DESCRIPTION
Flamegraph::StackProfSampler throws a `undefined method '[]' for nil:NilClass (NoMethodError)` when result is nil.  Added a simple guard.

In my particular use case, I'm trying to flamegraph a request which uses Doorkeeper middleware, which seems to raise and return 401 Unauthorized.  This causes `result` to be nil, and thus explodes the sampler.  Adding the guard allows the flamegraph to render as expected.  Hopefully this is a safe change.