### PR TITLE
Fix same node columns with different parents

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,5 @@ gemspec
 
 # both are optional, depending on platform
 gem 'fast_stack'
-gem 'stackprof', platform: :mri_21
+gem 'stackprof', platform: [:mri_21, :mri_22, :mri_23]
+

--- a/lib/flamegraph/renderer.rb
+++ b/lib/flamegraph/renderer.rb
@@ -32,12 +32,13 @@ class Flamegraph::Renderer
       next unless stack
 
       col = []
+      new_col = false
 
       reversed_stack = stack.reverse
       reversed_stack.map{|r| r.to_s}.each_with_index do |frame, i|
         parent_frame = i > 0 ? reversed_stack[i - 1] : nil
 
-        if !prev[i].nil?
+        if !prev[i].nil? && !new_col
           last_col = prev[i]
           frame_match = last_col[0] == frame
           parent_match = parent_frame.nil? || prev_parent[i].nil? || parent_frame == prev_parent[i]
@@ -46,6 +47,8 @@ class Flamegraph::Renderer
             last_col[1] += 1
             col << nil
             next
+          else
+            new_col = true
           end
         end
 

--- a/lib/flamegraph/renderer.rb
+++ b/lib/flamegraph/renderer.rb
@@ -24,6 +24,7 @@ class Flamegraph::Renderer
   def graph_data
     table = []
     prev = []
+    prev_parent = []
 
     # a 2d array makes collapsing easy
     @stacks.each_with_index do |stack, pos|
@@ -32,11 +33,16 @@ class Flamegraph::Renderer
 
       col = []
 
-      stack.reverse.map{|r| r.to_s}.each_with_index do |frame, i|
+      reversed_stack = stack.reverse
+      reversed_stack.map{|r| r.to_s}.each_with_index do |frame, i|
+        parent_frame = i > 0 ? reversed_stack[i - 1] : nil
 
         if !prev[i].nil?
           last_col = prev[i]
-          if last_col[0] == frame
+          frame_match = last_col[0] == frame
+          parent_match = parent_frame.nil? || prev_parent[i].nil? || parent_frame == prev_parent[i]
+
+          if frame_match && parent_match
             last_col[1] += 1
             col << nil
             next
@@ -44,6 +50,7 @@ class Flamegraph::Renderer
         end
 
         prev[i] = [frame, 1]
+        prev_parent[i] = parent_frame
         col << prev[i]
       end
       prev = prev[0..col.length-1].to_a

--- a/test/test_renderer.rb
+++ b/test/test_renderer.rb
@@ -17,6 +17,21 @@ class TestRenderer < Minitest::Test
 
   end
 
+  def test_builds_table_correctly_for_different_grandparents
+    stacks = [["method4","method3","method1"],["method4","method3","method1"],["method4","method3","method2"]]
+
+    g = Flamegraph::Renderer.new(stacks)
+    assert_equal([
+        {:x => 1, :y => 1, :frame => "method1", :width => 2},
+        {:x => 1, :y => 2, :frame => "method3", :width => 2},
+        {:x => 1, :y => 3, :frame => "method4", :width => 2},
+        {:x => 3, :y => 1, :frame => "method2", :width => 1},
+        {:x => 3, :y => 2, :frame => "method3", :width => 1},
+        {:x => 3, :y => 3, :frame => "method4", :width => 1}
+    ], g.graph_data)
+
+  end
+
   def test_avoids_bridges
     stacks = [["3","2","1"],["4","1"],["4","5"]]
 

--- a/test/test_renderer.rb
+++ b/test/test_renderer.rb
@@ -10,8 +10,9 @@ class TestRenderer < Minitest::Test
         {:x => 1, :y => 1, :frame => "1", :width => 2},
         {:x => 1, :y => 2, :frame => "2", :width => 1},
         {:x => 1, :y => 3, :frame => "3", :width => 1},
-        {:x => 2, :y => 2, :frame => "4", :width => 2},
-        {:x => 3, :y => 1, :frame => "5", :width => 1}
+        {:x => 2, :y => 2, :frame => "4", :width => 1},
+        {:x => 3, :y => 1, :frame => "5", :width => 1},
+        {:x => 3, :y => 2, :frame => "4", :width => 1}
     ], g.graph_data)
 
   end
@@ -25,8 +26,9 @@ class TestRenderer < Minitest::Test
         {:x => 1, :y => 1, :frame => "1", :width => 2},
         {:x => 1, :y => 2, :frame => "2", :width => 1},
         {:x => 1, :y => 3, :frame => "3", :width => 1},
-        {:x => 2, :y => 2, :frame => "4", :width => 2},
-        {:x => 3, :y => 1, :frame => "5", :width => 1}
+        {:x => 2, :y => 2, :frame => "4", :width => 1},
+        {:x => 3, :y => 1, :frame => "5", :width => 1},
+        {:x => 3, :y => 2, :frame => "4", :width => 1}
     ], g.graph_data)
 
 


### PR DESCRIPTION
Hey @SamSaffron,

Opening a different pull request for this issue. I'll be merging it into #24 soon.

The case is when a node is wider than it's parent. This happens when both method1 and method2 call method3. If method1 is 3 samples and method2 is 2 samples, method3 appears as a node with 5 samples.

method3 should appear as two nodes, first with 3 samples and as a child of method1. And then with 2 samples and as a child of method2.

This PR fixes that scenario. I modified the tests and added a new one to cover a slightly different case.

I had originally fixed this in the javascript as part of #24, but for very large datasets (over 50MB) the javascript crashes because it has to modify the processed data. It's much faster to do on the ruby side. Creating a PR off of master to isolate the issue.