### PR TITLE
added 'hide_x_bottom_lines' and 'sort_alphabetically' options

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,12 @@ Flamegraph.generate(filename, hide_x_bottom_lines: 20) do
 end
 
 # will order stacktraces alphabetically, like the original Flamegraph (https://github.com/brendangregg/FlameGraph) does
-Flamegraph.generate(filename, sort_alphabetically: true) do
+Flamegraph.generate(filename, sort_alphabetically: true) do # TODO: consider https://gist.github.com/BrVer/9854d6fb5b9546987c49e0dcf8ead380 instead
   # your work here
 end
 
 ```
+
 
 ## Demo
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,22 @@ end
 
 ```
 
+You can also pass some options:
+
+```ruby
+
+# will hide bottom x lines of the graph
+Flamegraph.generate(filename, hide_x_bottom_lines: 20) do
+  # your work here
+end
+
+# will order stacktraces alphabetically, like the original Flamegraph (https://github.com/brendangregg/FlameGraph) does
+Flamegraph.generate(filename, sort_alphabetically: true) do
+  # your work here
+end
+
+```
+
 ## Demo
 
 Demo of: https://github.com/SamSaffron/flamegraph/blob/master/demo/demo.rb

--- a/lib/flamegraph.rb
+++ b/lib/flamegraph.rb
@@ -44,6 +44,12 @@ module Flamegraph
           yield
         end
       end
+    if opts[:hide_x_bottom_lines]
+      backtraces.map! { |b| b[0..-(opts[:hide_bottom_lines].to_i + 1)] }.reject(&:empty?)
+    end
+    if opts[:sort_alphabetically]
+      backtraces.sort_by! {|b| b.reverse.join('---')}
+    end
 
     embed_resources = (filename && !opts.key?(:embed_resources)) || opts[:embed_resources]
 

--- a/lib/flamegraph.rb
+++ b/lib/flamegraph.rb
@@ -45,7 +45,7 @@ module Flamegraph
         end
       end
     if opts[:hide_x_bottom_lines]
-      backtraces.map! { |b| b[0..-(opts[:hide_bottom_lines].to_i + 1)] }.reject(&:empty?)
+      backtraces.map! { |b| b[0..-(opts[:hide_x_bottom_lines].to_i + 1)] }.reject(&:empty?)
     end
     if opts[:sort_alphabetically]
       backtraces.sort_by! {|b| b.reverse.join('---')}


### PR DESCRIPTION
Tool works nice, however I missed some functionality:
1) ability to not display X bottom lines of the stacktrace, as it's usually some rails initialization stuff which only takes extra place
2) ability to sort stacktraces alphabetically, so the same stacktraces will be grouped into one big column instead of being splitted across the chart

The second option gives next benefits:
- it's really easy to visually determine which parts of code take the most CPU time
- chart size is reduced dramatically, especially if you're using much loops in your code (for me it reduced from 40MB, which crashed browser tab, to ~1.5MB which can be opened without such risk)
- original flamegraph (https://github.com/brendangregg/FlameGraph) works this way, so it will be convenient to add such option