### PR TITLE
Prevent opening dialog box while dragging graph.

### DIFF
--- a/lib/flamegraph/flamegraph.html
+++ b/lib/flamegraph/flamegraph.html
@@ -306,6 +306,10 @@ $(window).keyup(function(e) {
 });
 
 var click = function(d){
+  if (d3.event.defaultPrevented) {
+      return;
+  }
+
   var trace = backtrace(d);
 
   var link = function(path, dest){


### PR DESCRIPTION
When dragging the graph, as soon as you mouseup the dialog box will open. I think it's pretty annoying for very large graphs.

https://stackoverflow.com/a/19077477